### PR TITLE
Use the new build env on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,4 @@ notifications:
       - austin@rubyforge.org
     on_success: change
     on_failure: always
+sudo: false


### PR DESCRIPTION
More RAM, dedicated cpu cores, awesome network performance, fantastic VM boot times.

> Using our new container-based stack only requires one additional line in your .travis.yml:
> `sudo: false`

Source: http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/